### PR TITLE
args_parser: Bug fix and enhancement of positional argument handling.

### DIFF
--- a/hebench/modules/args_parser/src/args_parser.cpp
+++ b/hebench/modules/args_parser/src/args_parser.cpp
@@ -130,9 +130,10 @@ void ArgsParser::parse(int argc, const char *const argv[], int start_index)
         // get program name if available
         if (argc > 0 && start_index > 0)
             m_program_name = std::filesystem::path(argv[0]).filename();
-        else
-            m_program_name = DefaultProgramName;
     } // end if
+
+    if (m_program_name.empty())
+        m_program_name = DefaultProgramName;
 
     int i = start_index;
     while (i < argc)

--- a/hebench/modules/args_parser/src/args_parser.cpp
+++ b/hebench/modules/args_parser/src/args_parser.cpp
@@ -72,6 +72,9 @@ ArgsParser::ArgsParser(bool bshow_help,
     if (!m_epilogue.empty())
         m_epilogue = ArgsParser::fixHelpText(m_epilogue, 0, m_line_size);
 
+    if (margin_size >= line_size)
+        throw std::invalid_argument("`margin_size` must be less than `line_size`.");
+
     if (bshow_help)
     {
         std::string help_text = (m_margin_size <= 0 ? std::string(4, ' ') : std::string()) + "Shows this help.";
@@ -123,7 +126,7 @@ void ArgsParser::parse(int argc, const char *const argv[], int start_index)
     if (argc < 0)
         argc = 0;
     if (argc < start_index)
-        throw std::invalid_argument("Not enough arguments.");
+        throw std::invalid_argument("Not enough arguments to parse.");
 
     if (m_program_name.empty())
     {


### PR DESCRIPTION
## Proposed changes

- Fixed a bug that prevented the help flag from being recognized when there were more than 1 positional arguments required.
- Made positional arguments work closer to python version where they can be interspersed among option arguments.
- Positional arguments are now "optional" and users should check whether a parsed command line contained all the positional arguments they expected, and error out oif any non-optional positional arguments were missed, or supply default values.

## Types of changes

What types of changes does your code introduce to the HEBench Common Library?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hebench/common-lib/blob/main/CONTRIBUTING.md) doc
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Please, make sure this change does not break mainline Test Harness before approving.